### PR TITLE
RecentCache node handle comparison bugfix

### DIFF
--- a/src/CSharpTest.Net.Collections/Collections/NodeCache.Base.cs
+++ b/src/CSharpTest.Net.Collections/Collections/NodeCache.Base.cs
@@ -89,7 +89,7 @@ namespace CSharpTest.Net.Collections
             public abstract ILockStrategy CreateLock(NodeHandle handle, out object refobj);
             protected abstract NodePin Lock(NodePin parent, LockType ltype, NodeHandle child);
 
-            public NodePin LockRoot(LockType ltype)
+            public virtual NodePin LockRoot(LockType ltype)
             {
                 return Lock(null, ltype, RootHandle);
             }


### PR DESCRIPTION
Complete bug information posted at: http://stackoverflow.com/questions/35745332/csharptest-net-collections-bplustree-recentcache-bug/41483216#41483216